### PR TITLE
gstreamer1.0-plugins-bad: Add libgudev to depends

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
@@ -2,7 +2,7 @@ require gstreamer1.0-plugins.inc
 
 LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+"
 
-DEPENDS += "gstreamer1.0-plugins-base libpng jpeg"
+DEPENDS += "gstreamer1.0-plugins-base libpng jpeg libgudev"
 
 inherit gettext bluetooth
 


### PR DESCRIPTION
Fix error:
/
|gst-plugins-bad-1.12.4/gst-libs/gst/gl/gbm/gstgl_gbm_private.c:24:10:
| fatal error: gudev/gudev.h: No such file or directory
|  #include <gudev/gudev.h>
|           ^~~~~~~~~~~~~~~
| compilation terminated.
\

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>