### PR TITLE
Rename distro_features_check to features_check

### DIFF
--- a/recipes-multimedia/gstreamer/gst-examples_git.bb
+++ b/recipes-multimedia/gstreamer/gst-examples_git.bb
@@ -14,7 +14,7 @@ PV = "1.16.0"
 
 S = "${WORKDIR}/git"
 
-inherit meson pkgconfig distro_features_check
+inherit meson pkgconfig features_check
 
 
 ANY_OF_DISTRO_FEATURES = "${GTK3DISTROFEATURES}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-python_1.16.2.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-python_1.16.2.bb
@@ -20,7 +20,7 @@ S = "${WORKDIR}/${PNREAL}-${PV}"
 REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"
 UNKNOWN_CONFIGURE_WHITELIST_append = " --enable-introspection --disable-introspection"
 
-inherit autotools pkgconfig distutils3-base upstream-version-is-even gobject-introspection distro_features_check
+inherit autotools pkgconfig distutils3-base upstream-version-is-even gobject-introspection features_check
 
 EXTRA_OECONF += "--with-libpython-dir=${libdir}"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.16.2.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.16.2.bb
@@ -19,7 +19,7 @@ SRC_URI[sha256sum] = "191de7b0ab64a85dd0875c990721e7be95518f60e2a9106beca162004e
 S = "${WORKDIR}/${REALPN}-${PV}"
 DEPENDS = "libva gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
 
-inherit autotools pkgconfig gtk-doc distro_features_check upstream-version-is-even
+inherit autotools pkgconfig gtk-doc features_check upstream-version-is-even
 
 REQUIRED_DISTRO_FEATURES ?= "opengl"
 


### PR DESCRIPTION
As of OE-Core commit 4c00e5fed9532fe6ee71ce96b0124fc234b44d4e
change distro_feature_check to features_check, we're replacing
to avoid warning messages due to the class rename.

Signed-off-by: Domarys Correa <domarys.correa@ossystems.com.br>