### PR TITLE
Fetch git tag based on package version

### DIFF
--- a/recipes-multimedia/gstreamer/gst-devtools_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gst-devtools_1.18.0.bb
@@ -8,8 +8,7 @@ LIC_FILES_CHKSUM = "file://validate/COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343
 
 S = "${WORKDIR}/git"
 
-SRCREV = "796b7caad02fc69a060865d23e8e8d53500991e4"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-devtools.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-devtools.git;protocol=https;nobranch=1;tag=${PV} \
            file://0001-connect-has-a-different-signature-on-musl.patch \
            "
 

--- a/recipes-multimedia/gstreamer/gst-examples_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gst-examples_1.18.0.bb
@@ -4,12 +4,10 @@ LIC_FILES_CHKSUM = "file://playback/player/gtk/gtk-play.c;beginline=1;endline=20
 
 DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gtk+3 libsoup-2.4 json-glib glib-2.0-native"
 
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-examples.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-examples.git;protocol=https;nobranch=1;tag=${PV} \
            file://0001-Make-player-examples-installable.patch \
            file://gst-player.desktop \
            "
-
-SRCREV = "009290dc8784e6714dc2a29be123110c14a38123"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_1.18.0.bb
@@ -9,8 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
                     file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
                     "
 
-SRCREV = "215b3ed959f2b307065319f94855cc9e1ce7be95"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-libav.git;protocol=https"
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-libav.git;protocol=https;nobranch=1;tag=${PV}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.18.0.bb
@@ -7,8 +7,7 @@ LICENSE_FLAGS = "commercial"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
                     file://omx/gstomx.h;beginline=1;endline=21;md5=5c8e1fca32704488e76d2ba9ddfa935f"
 
-SRCREV = "f5efdba36c64ac2bf826cee34642e7fd54104ab1"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-omx.git;protocol=https"
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-omx.git;protocol=https;nobranch=1;tag=${PV}"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.bb
@@ -1,7 +1,6 @@
 require gstreamer1.0-plugins-common.inc
 
-SRCREV = "7cb583bb0427819a6b59b783e7df67961df2155f"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git;protocol=https;nobranch=1;tag=${PV} \
            file://0001-fix-maybe-uninitialized-warnings-when-compiling-with.patch \
            file://0002-avoid-including-sys-poll.h-directly.patch \
            file://0003-ensure-valid-sentinals-for-gst_structure_get-etc.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.bb
@@ -3,8 +3,7 @@ require gstreamer1.0-plugins-common.inc
 LICENSE = "GPLv2+ & LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d"
 
-SRCREV = "f21623c1f60949ed6a77e2c2c3857be942cd2db5"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git;protocol=https;nobranch=1;tag=${PV} \
            file://0001-ENGR00312515-get-caps-from-src-pad-when-query-caps.patch \
            file://0003-viv-fb-Make-sure-config.h-is-included.patch \
            file://0002-ssaparse-enhance-SSA-text-lines-parsing.patch \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.bb
@@ -1,7 +1,6 @@
 require gstreamer1.0-plugins-common.inc
 
-SRCREV = "6ef694ce7b40dda9f2163ed5e1b1de7378505ad0"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git;protocol=https;nobranch=1;tag=${PV} \
            file://0001-qt-include-ext-qt-gstqtgl.h-instead-of-gst-gl-gstglf.patch \
            "
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.18.0.bb
@@ -6,8 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
 LICENSE = "GPLv2+ & LGPLv2.1+ & LGPLv2+"
 LICENSE_FLAGS = "commercial"
 
-SRCREV = "ae91a81d9aa913cee1e8310af93a8fff5445628d"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git;protocol=https"
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git;protocol=https;nobranch=1;tag=${PV}"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-python_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-python_1.18.0.bb
@@ -5,8 +5,7 @@ SECTION = "multimedia"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c34deae4e395ca07e725ab0076a5f740"
 
-SRCREV = "a85f99e274fe14348645c61606463ff63ceb45eb"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-python.git;protocol=https"
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-python.git;protocol=https;nobranch=1;tag=${PV}"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-rtsp-server_1.18.0.bb
@@ -6,8 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d"
 
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
 
-SRCREV = "12eef972482ab3243743ae1bda1c40fc4411782c"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-rtsp-server.git;protocol=https"
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-rtsp-server.git;protocol=https;nobranch=1;tag=${PV}"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-vaapi_1.18.0.bb
@@ -6,8 +6,7 @@ based plugins for GStreamer and helper libraries: `vaapidecode', \
 LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
 
-SRCREV = "de6fb60929252d6ee066aa06e25302a3f4a9856e"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi.git;protocol=https"
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi.git;protocol=https;nobranch=1;tag=${PV}"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.bb
@@ -15,8 +15,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
 
 S = "${WORKDIR}/git"
 
-SRCREV = "96148da56f9cbf23120e51ce59ab90f94d8b19b8"
-SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gstreamer.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gstreamer.git;protocol=https;nobranch=1;tag=${PV} \
            file://0001-gst-gstpluginloader.c-when-env-var-is-set-do-not-fal.patch \
            file://0002-Remove-unused-valgrind-detection.patch \
            file://0003-meson-Add-option-for-installed-tests.patch \


### PR DESCRIPTION
Use git tag instead of commit revision to fetch sources. This simplify
the update process, once it's need only rename the recipe to the new
release.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>