### PR TITLE
[master] layer compat

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_COLLECTIONS += "gstreamer1.0"
 BBFILE_PATTERN_gstreamer1.0 := "^${LAYERDIR}/"
 BBFILE_PRIORITY_gstreamer1.0 = "6"
 
-LAYERSERIES_COMPAT_gstreamer1.0 = "master"
+LAYERSERIES_COMPAT_gstreamer1.0 = "gatesgarth"


### PR DESCRIPTION
OE-Core master as `LAYERSERIES_COMPAT_core = "gatesgarth"` so the commit https://github.com/OSSystems/meta-gstreamer1.0/commit/9fc17ccc5360fa2da3e30785728d1ef48425e6c8 doesn't make sense at all.

To revert this we need to re add the dependencies tools needs to build the vulkan plugin.
This is mainly because the OE-Core gatesgarth branch don't have this tools.

Thanks to @fbertux that found the `LAYERSERIES_COMPAT=master` issue
